### PR TITLE
Make install and systemd service files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ethersrv-linux: ethersrv-linux.c fs.c fs.h lock.c lock.h debug.h
 clean:
 	rm -f ethersrv-linux *.o
 
-install:
+install: ethersrv-linux
 	install -m 755 ethersrv-linux /usr/sbin
 	install -m 644 ethersrv.service /lib/systemd/system
 	install -m 644 -T ethersrv.def /etc/default/ethersrv

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,8 @@ ethersrv-linux: ethersrv-linux.c fs.c fs.h lock.c lock.h debug.h
 
 clean:
 	rm -f ethersrv-linux *.o
+
+install:
+	install -m 755 ethersrv-linux /usr/sbin
+	install -m 644 ethersrv.service /lib/systemd/system
+	install -m 644 -T ethersrv.def /etc/default/ethersrv

--- a/ethersrv.def
+++ b/ethersrv.def
@@ -1,0 +1,5 @@
+# List of root folders to share
+ETHERSRV_SHARES="/mnt/dos_c /mnt/dos_d"
+
+# Ethernet interface to operate on
+ETHERSRV_INTERFACE="eth0"

--- a/ethersrv.service
+++ b/ethersrv.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=EtherDFS Server
+Wants=network-online.target
+After=network.target network-online.target 
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/default/ethersrv
+ExecStart=/usr/sbin/ethersrv-linux -f ${ETHERSRV_INTERFACE} $ETHERSRV_SHARES
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This adds a `make install` target to the Makefile which also installs a systemd service file and config file.

* binary installs to /usr/sbin
* `ethersrv.service` is installed (but not activated)
* `/etc/default/ethersrv` contains the settings for the server (interface and list of shares).
